### PR TITLE
Add suport for FY6900

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@
 generators.  It was developed with the
 [FY2300](http://en.feeltech.net/index.php?case=archive&act=show&aid=17) which is
 nearly identical to the
-[FY6600](http://en.feeltech.net/index.php?case=archive&act=show&aid=59) and
-[FY6800](http://en.feeltech.net/index.php?case=archive&act=show&aid=61) in
+[FY6600](http://en.feeltech.net/index.php?case=archive&act=show&aid=59),
+[FY6800](http://en.feeltech.net/index.php?case=archive&act=show&aid=61) and
+[FY6900](http://en.feeltech.net/index.php?case=archive&act=show&aid=65) in
 features.  Other generators should also work, although some tweaks may be
 required.
 
@@ -89,6 +90,12 @@ value.
     import fygen
     fy = fygen.FYGen('/dev/ttyUSB0', debug_level=1)
     fy = fygen.FYGen(debug_level=1)  # Same thing
+    
+    # In case you get UnsupportedDeviceError, you can manually specify
+    # one of the supported devices that may be compatible.
+    # The id's of waveforms are different between models,
+    # so you might not get the waveform you ask for
+    fy = fygen.FyGen(device_name='fy2300')
     
 Once connected, this command will setup a 1Mhz sin wave on the main channel:
 
@@ -165,106 +172,108 @@ press enter.
 See `examples/lowlevel` for some code examples.
 
 # Available Waveforms
-|Name           |Description                             |Channels|
-|---------------|----------------------------------------|--------|
-|`sin`          |Sin                                     |    0, 1|
-|`square`       |Square                                  |    0, 1|
-|`cmos`         |CMOS                                    |    0, 1|
-|`adj-pulse`    |Adjustable Pulse                        |       0|
-|`dc`           |DC                                      |    0, 1|
-|`tri`          |Triangle                                |    0, 1|
-|`ramp`         |Ramp                                    |    0, 1|
-|`neg-ramp`     |Negative Ramp                           |    0, 1|
-|`stair-tri`    |Stairstep Triangle                      |    0, 1|
-|`stair`        |Stairstep                               |    0, 1|
-|`neg-stair`    |Negative Stairstep                      |    0, 1|
-|`exp`          |Exponential                             |    0, 1|
-|`neg-exp`      |Negative Exponential                    |    0, 1|
-|`fall-exp`     |Falling Exponential                     |    0, 1|
-|`neg-fall-exp` |Negative Falling Exponential            |    0, 1|
-|`log`          |Logarithm                               |    0, 1|
-|`neg-log`      |Negative Logarithm                      |    0, 1|
-|`fall-log`     |Falling Logarithm                       |    0, 1|
-|`neg-fall-log` |Negative Falling Logarithm              |    0, 1|
-|`full-wav`     |Full Wave                               |    0, 1|
-|`neg-full-wav` |Negative Full Wave                      |    0, 1|
-|`half-wav`     |Half Wave                               |    0, 1|
-|`neg-half-wav` |Negative Half Wave                      |    0, 1|
-|`lorentz`      |Lorentz Pulse                           |    0, 1|
-|`multitone`    |Multitone                               |    0, 1|
-|`rand`         |Random                                  |    0, 1|
-|`ecg`          |ECG                                     |    0, 1|
-|`trap`         |Trapezoidal Pulse                       |    0, 1|
-|`sinc`         |Sinc Pulse                              |    0, 1|
-|`impulse`      |Impulse                                 |    0, 1|
-|`gauss`        |Gauss White Noise                       |    0, 1|
-|`am`           |AM                                      |    0, 1|
-|`fm`           |FM                                      |    0, 1|
-|`chirp`        |Chirp                                   |    0, 1|
-|`arb1`         |Arbitrary Waveform 1                    |    0, 1|
-|`arb2`         |Arbitrary Waveform 2                    |    0, 1|
-|`arb3`         |Arbitrary Waveform 3                    |    0, 1|
-|`arb4`         |Arbitrary Waveform 4                    |    0, 1|
-|`arb5`         |Arbitrary Waveform 5                    |    0, 1|
-|`arb6`         |Arbitrary Waveform 6                    |    0, 1|
-|`arb7`         |Arbitrary Waveform 7                    |    0, 1|
-|`arb8`         |Arbitrary Waveform 8                    |    0, 1|
-|`arb9`         |Arbitrary Waveform 9                    |    0, 1|
-|`arb10`        |Arbitrary Waveform 10                   |    0, 1|
-|`arb11`        |Arbitrary Waveform 11                   |    0, 1|
-|`arb12`        |Arbitrary Waveform 12                   |    0, 1|
-|`arb13`        |Arbitrary Waveform 13                   |    0, 1|
-|`arb14`        |Arbitrary Waveform 14                   |    0, 1|
-|`arb15`        |Arbitrary Waveform 15                   |    0, 1|
-|`arb16`        |Arbitrary Waveform 16                   |    0, 1|
-|`arb17`        |Arbitrary Waveform 17                   |    0, 1|
-|`arb18`        |Arbitrary Waveform 18                   |    0, 1|
-|`arb19`        |Arbitrary Waveform 19                   |    0, 1|
-|`arb20`        |Arbitrary Waveform 20                   |    0, 1|
-|`arb21`        |Arbitrary Waveform 21                   |    0, 1|
-|`arb22`        |Arbitrary Waveform 22                   |    0, 1|
-|`arb23`        |Arbitrary Waveform 23                   |    0, 1|
-|`arb24`        |Arbitrary Waveform 24                   |    0, 1|
-|`arb25`        |Arbitrary Waveform 25                   |    0, 1|
-|`arb26`        |Arbitrary Waveform 26                   |    0, 1|
-|`arb27`        |Arbitrary Waveform 27                   |    0, 1|
-|`arb28`        |Arbitrary Waveform 28                   |    0, 1|
-|`arb29`        |Arbitrary Waveform 29                   |    0, 1|
-|`arb30`        |Arbitrary Waveform 30                   |    0, 1|
-|`arb31`        |Arbitrary Waveform 31                   |    0, 1|
-|`arb32`        |Arbitrary Waveform 32                   |    0, 1|
-|`arb33`        |Arbitrary Waveform 33                   |    0, 1|
-|`arb34`        |Arbitrary Waveform 34                   |    0, 1|
-|`arb35`        |Arbitrary Waveform 35                   |    0, 1|
-|`arb36`        |Arbitrary Waveform 36                   |    0, 1|
-|`arb37`        |Arbitrary Waveform 37                   |    0, 1|
-|`arb38`        |Arbitrary Waveform 38                   |    0, 1|
-|`arb39`        |Arbitrary Waveform 39                   |    0, 1|
-|`arb40`        |Arbitrary Waveform 40                   |    0, 1|
-|`arb41`        |Arbitrary Waveform 41                   |    0, 1|
-|`arb42`        |Arbitrary Waveform 42                   |    0, 1|
-|`arb43`        |Arbitrary Waveform 43                   |    0, 1|
-|`arb44`        |Arbitrary Waveform 44                   |    0, 1|
-|`arb45`        |Arbitrary Waveform 45                   |    0, 1|
-|`arb46`        |Arbitrary Waveform 46                   |    0, 1|
-|`arb47`        |Arbitrary Waveform 47                   |    0, 1|
-|`arb48`        |Arbitrary Waveform 48                   |    0, 1|
-|`arb49`        |Arbitrary Waveform 49                   |    0, 1|
-|`arb50`        |Arbitrary Waveform 50                   |    0, 1|
-|`arb51`        |Arbitrary Waveform 51                   |    0, 1|
-|`arb52`        |Arbitrary Waveform 52                   |    0, 1|
-|`arb53`        |Arbitrary Waveform 53                   |    0, 1|
-|`arb54`        |Arbitrary Waveform 54                   |    0, 1|
-|`arb55`        |Arbitrary Waveform 55                   |    0, 1|
-|`arb56`        |Arbitrary Waveform 56                   |    0, 1|
-|`arb57`        |Arbitrary Waveform 57                   |    0, 1|
-|`arb58`        |Arbitrary Waveform 58                   |    0, 1|
-|`arb59`        |Arbitrary Waveform 59                   |    0, 1|
-|`arb60`        |Arbitrary Waveform 60                   |    0, 1|
-|`arb61`        |Arbitrary Waveform 61                   |    0, 1|
-|`arb62`        |Arbitrary Waveform 62                   |    0, 1|
-|`arb63`        |Arbitrary Waveform 63                   |    0, 1|
-|`arb64`        |Arbitrary Waveform 64                   |    0, 1|
+|Name           |Description                   |Channels| Devices|
+|---------------|------------------------------|--------|--------|
+|`sin`          |Sin                           |    0, 1|     all|
+|`square`       |Square                        |    0, 1|     all|
+|`cmos`         |CMOS                          |    0, 1|     all|
+|`adj-pulse`    |Adjustable Pulse              |       0|     all|
+|`dc`           |DC                            |    0, 1|     all|
+|`tri`          |Triangle                      |    0, 1|     all|
+|`ramp`         |Ramp                          |    0, 1|     all|
+|`neg-ramp`     |Negative Ramp                 |    0, 1|     all|
+|`stair-tri`    |Stairstep Triangle            |    0, 1|     all|
+|`stair`        |Stairstep                     |    0, 1|     all|
+|`neg-stair`    |Negative Stairstep            |    0, 1|     all|
+|`exp`          |Exponential                   |    0, 1|     all|
+|`neg-exp`      |Negative Exponential          |    0, 1|     all|
+|`fall-exp`     |Falling Exponential           |    0, 1|     all|
+|`neg-fall-exp` |Negative Falling Exponential  |    0, 1|     all|
+|`log`          |Logarithm                     |    0, 1|     all|
+|`neg-log`      |Negative Logarithm            |    0, 1|     all|
+|`fall-log`     |Falling Logarithm             |    0, 1|     all|
+|`neg-fall-log` |Negative Falling Logarithm    |    0, 1|     all|
+|`full-wav`     |Full Wave                     |    0, 1|     all|
+|`neg-full-wav` |Negative Full Wave            |    0, 1|     all|
+|`half-wav`     |Half Wave                     |    0, 1|     all|
+|`neg-half-wav` |Negative Half Wave            |    0, 1|     all|
+|`lorentz`      |Lorentz Pulse                 |    0, 1|     all|
+|`multitone`    |Multitone                     |    0, 1|     all|
+|`rand`         |Random                        |    0, 1|     all|
+|`ecg`          |ECG                           |    0, 1|     all|
+|`trap`         |Trapezoidal Pulse             |    0, 1|     all|
+|`sinc`         |Sinc Pulse                    |    0, 1|     all|
+|`impulse`      |Impulse                       |    0, 1|     all|
+|`gauss`        |Gauss White Noise             |    0, 1|     all|
+|`am`           |AM                            |    0, 1|     all|
+|`fm`           |FM                            |    0, 1|     all|
+|`chirp`        |Chirp                         |    0, 1|     all|
+|`rectangle`    |Rectangle                     |    0, 1|  fy6900|
+|`tra`          |Trapezoid                     |    0, 1|  fy6900|
+|`arb1`         |Arbitrary Waveform 1          |    0, 1|     all|
+|`arb2`         |Arbitrary Waveform 2          |    0, 1|     all|
+|`arb3`         |Arbitrary Waveform 3          |    0, 1|     all|
+|`arb4`         |Arbitrary Waveform 4          |    0, 1|     all|
+|`arb5`         |Arbitrary Waveform 5          |    0, 1|     all|
+|`arb6`         |Arbitrary Waveform 6          |    0, 1|     all|
+|`arb7`         |Arbitrary Waveform 7          |    0, 1|     all|
+|`arb8`         |Arbitrary Waveform 8          |    0, 1|     all|
+|`arb9`         |Arbitrary Waveform 9          |    0, 1|     all|
+|`arb10`        |Arbitrary Waveform 10         |    0, 1|     all|
+|`arb11`        |Arbitrary Waveform 11         |    0, 1|     all|
+|`arb12`        |Arbitrary Waveform 12         |    0, 1|     all|
+|`arb13`        |Arbitrary Waveform 13         |    0, 1|     all|
+|`arb14`        |Arbitrary Waveform 14         |    0, 1|     all|
+|`arb15`        |Arbitrary Waveform 15         |    0, 1|     all|
+|`arb16`        |Arbitrary Waveform 16         |    0, 1|     all|
+|`arb17`        |Arbitrary Waveform 17         |    0, 1|     all|
+|`arb18`        |Arbitrary Waveform 18         |    0, 1|     all|
+|`arb19`        |Arbitrary Waveform 19         |    0, 1|     all|
+|`arb20`        |Arbitrary Waveform 20         |    0, 1|     all|
+|`arb21`        |Arbitrary Waveform 21         |    0, 1|     all|
+|`arb22`        |Arbitrary Waveform 22         |    0, 1|     all|
+|`arb23`        |Arbitrary Waveform 23         |    0, 1|     all|
+|`arb24`        |Arbitrary Waveform 24         |    0, 1|     all|
+|`arb25`        |Arbitrary Waveform 25         |    0, 1|     all|
+|`arb26`        |Arbitrary Waveform 26         |    0, 1|     all|
+|`arb27`        |Arbitrary Waveform 27         |    0, 1|     all|
+|`arb28`        |Arbitrary Waveform 28         |    0, 1|     all|
+|`arb29`        |Arbitrary Waveform 29         |    0, 1|     all|
+|`arb30`        |Arbitrary Waveform 30         |    0, 1|     all|
+|`arb31`        |Arbitrary Waveform 31         |    0, 1|     all|
+|`arb32`        |Arbitrary Waveform 32         |    0, 1|     all|
+|`arb33`        |Arbitrary Waveform 33         |    0, 1|     all|
+|`arb34`        |Arbitrary Waveform 34         |    0, 1|     all|
+|`arb35`        |Arbitrary Waveform 35         |    0, 1|     all|
+|`arb36`        |Arbitrary Waveform 36         |    0, 1|     all|
+|`arb37`        |Arbitrary Waveform 37         |    0, 1|     all|
+|`arb38`        |Arbitrary Waveform 38         |    0, 1|     all|
+|`arb39`        |Arbitrary Waveform 39         |    0, 1|     all|
+|`arb40`        |Arbitrary Waveform 40         |    0, 1|     all|
+|`arb41`        |Arbitrary Waveform 41         |    0, 1|     all|
+|`arb42`        |Arbitrary Waveform 42         |    0, 1|     all|
+|`arb43`        |Arbitrary Waveform 43         |    0, 1|     all|
+|`arb44`        |Arbitrary Waveform 44         |    0, 1|     all|
+|`arb45`        |Arbitrary Waveform 45         |    0, 1|     all|
+|`arb46`        |Arbitrary Waveform 46         |    0, 1|     all|
+|`arb47`        |Arbitrary Waveform 47         |    0, 1|     all|
+|`arb48`        |Arbitrary Waveform 48         |    0, 1|     all|
+|`arb49`        |Arbitrary Waveform 49         |    0, 1|     all|
+|`arb50`        |Arbitrary Waveform 50         |    0, 1|     all|
+|`arb51`        |Arbitrary Waveform 51         |    0, 1|     all|
+|`arb52`        |Arbitrary Waveform 52         |    0, 1|     all|
+|`arb53`        |Arbitrary Waveform 53         |    0, 1|     all|
+|`arb54`        |Arbitrary Waveform 54         |    0, 1|     all|
+|`arb55`        |Arbitrary Waveform 55         |    0, 1|     all|
+|`arb56`        |Arbitrary Waveform 56         |    0, 1|     all|
+|`arb57`        |Arbitrary Waveform 57         |    0, 1|     all|
+|`arb58`        |Arbitrary Waveform 58         |    0, 1|     all|
+|`arb59`        |Arbitrary Waveform 59         |    0, 1|     all|
+|`arb60`        |Arbitrary Waveform 60         |    0, 1|     all|
+|`arb61`        |Arbitrary Waveform 61         |    0, 1|     all|
+|`arb62`        |Arbitrary Waveform 62         |    0, 1|     all|
+|`arb63`        |Arbitrary Waveform 63         |    0, 1|     all|
+|`arb64`        |Arbitrary Waveform 64         |    0, 1|     all|
 
 # Custom Waveforms
 

--- a/examples/basic/all_waves.py
+++ b/examples/basic/all_waves.py
@@ -36,7 +36,7 @@ PARSER.add_argument(
     '--device',
     help='select signal generator',
     type=str,
-    default='fy2300'
+    default=None,
 )
 
 PARSER.add_argument(
@@ -50,7 +50,7 @@ ARGS = PARSER.parse_args()
 def show_waves(fy, c):
   """Show waves for a given channel."""
   fy.set(channel=1-c, wave='sin')
-  waves = wavedef.get_valid_list(ARGS.device, c)
+  waves = wavedef.get_valid_list(fy.device_name, c)
 
   if not ARGS.include_arbitrary:
     waves = list(w for w in waves if not w.startswith('arb'))
@@ -64,9 +64,9 @@ def show_waves(fy, c):
 def main():
   """Main function."""
   if ARGS.dry_run:
-    fy = fygen.FYGen(port=sys.stdout)
+    fy = fygen.FYGen(port=sys.stdout, device_name=ARGS.device)
   else:
-    fy = fygen.FYGen(debug_level=ARGS.debug_level)
+    fy = fygen.FYGen(debug_level=ARGS.debug_level, device_name=ARGS.device)
   fy.set(0, freq_hz=10000, volts=2, offset_volts=2, enable=True)
   fy.set(1, freq_hz=10000, volts=2, offset_volts=-2, enable=True)
   show_waves(fy, 0)

--- a/fygen_help.py
+++ b/fygen_help.py
@@ -33,8 +33,9 @@ _HELP['Introduction'] = """
 generators.  It was developed with the
 [FY2300](http://en.feeltech.net/index.php?case=archive&act=show&aid=17) which is
 nearly identical to the
-[FY6600](http://en.feeltech.net/index.php?case=archive&act=show&aid=59) and
-[FY6800](http://en.feeltech.net/index.php?case=archive&act=show&aid=61) in
+[FY6600](http://en.feeltech.net/index.php?case=archive&act=show&aid=59),
+[FY6800](http://en.feeltech.net/index.php?case=archive&act=show&aid=61) and
+[FY6900](http://en.feeltech.net/index.php?case=archive&act=show&aid=65) in
 features.  Other generators should also work, although some tweaks may be
 required.
 
@@ -97,6 +98,12 @@ value.
     import fygen
     fy = fygen.FYGen('/dev/ttyUSB0', debug_level=1)
     fy = fygen.FYGen(debug_level=1)  # Same thing
+    
+    # In case you get UnsupportedDeviceError, you can manually specify
+    # one of the supported devices that may be compatible.
+    # The id's of waveforms are different between models,
+    # so you might not get the waveform you ask for
+    fy = fygen.FyGen(device_name='fy2300')
     
 Once connected, this command will setup a 1Mhz sin wave on the main channel:
 
@@ -620,7 +627,7 @@ class UnknownDeviceError(Error):
 # pylint: disable=redefined-builtin
 def help(
     section,
-    device,
+    device=None,
     fout=sys.stdout,
     show_other_sections=True,
     markdown_format=False):

--- a/make_readme.py
+++ b/make_readme.py
@@ -17,7 +17,7 @@ def main():
     for section_idx in range(len(fygen_help.SECTIONS)):
       fygen_help.help(
           section=section_idx,
-          device='',
+          device=None,
           fout=fout,
           show_other_sections=False,
           markdown_format=True)

--- a/wavedef.py
+++ b/wavedef.py
@@ -27,9 +27,10 @@ class UnsupportedDeviceError(Error):
 # If your device is not in SUPPORTED_DEVICES you can pick one and it might
 # mostly work anyway.
 SUPPORTED_DEVICES = set((
-    '',
     'fy2300',
+    'fy6600',
     'fy6800',
+    'fy6900',
 ))
 
 # For consistency and better descriptions, all waveform names must be
@@ -55,11 +56,13 @@ _REPLACE_CODES = {
     'pulse': 'Pulse',
     'ramp': 'Ramp',
     'rand': 'Random',
+    'rectangle': 'Rectangle',
     'stair': 'Stairstep',
     'sin': 'Sin',
     'sinc': 'Sinc Pulse',
     'square': 'Square',
     'trap': 'Trapezoidal Pulse',
+    'tra': 'Trapezoid',
     'tri': 'Triangle',
     'wav': 'Wave',
 }
@@ -99,7 +102,10 @@ class WaveformDef(object):
         new_words.append(_REPLACE_CODES[word])
       else:
         raise InvalidNameError(
-            'Waveform name must consist of REPLACE_CODES separated by dashes')
+            'Waveform name ("%s") must consist of REPLACE_CODES '
+            'separated by dashes' %
+            name
+        )
 
     self.description = ' '.join(new_words)
 
@@ -115,7 +121,7 @@ class WaveformDef(object):
         raise InvalidMappingError(
             'mapping does not end with a valid channel: %s' % map_name)
 
-      if device_name not in SUPPORTED_DEVICES:
+      if device_name and device_name not in SUPPORTED_DEVICES:
         raise InvalidMappingError(
             'Device name not in SUPPORTED_DEVICES: %s' % map_name)
 
@@ -131,52 +137,62 @@ class WaveformDef(object):
     self.mappings = mappings
 # pylint: enable=too-few-public-methods
 
-# format
-_WAVEFORM_DEFS = [
-    WaveformDef('sin', {':': 0}),
-    WaveformDef('square', {':': 1}),
-    WaveformDef('cmos', {':': 2}),
-    WaveformDef('adj-pulse', {':0': 3}),
-    WaveformDef('dc', {':0': 4, ':1': 3}),
-    WaveformDef('tri', {':0': 5, ':1': 4}),
-    WaveformDef('ramp', {':0': 6, ':1': 5}),
-    WaveformDef('neg-ramp', {':0': 7, ':1': 6}),
-    WaveformDef('stair-tri', {':0': 8, ':1': 7}),
-    WaveformDef('stair', {':0': 9, ':1': 8}),
-    WaveformDef('neg-stair', {':0': 10, ':1': 9}),
-    WaveformDef('exp', {':0': 11, ':1': 10}),
-    WaveformDef('neg-exp', {':0': 12, ':1': 11}),
-    WaveformDef('fall-exp', {':0': 13, ':1': 12}),
-    WaveformDef('neg-fall-exp', {':0': 14, ':1': 13}),
-    WaveformDef('log', {':0': 15, ':1': 14}),
-    WaveformDef('neg-log', {':0': 16, ':1': 15}),
-    WaveformDef('fall-log', {':0': 17, ':1': 16}),
-    WaveformDef('neg-fall-log', {':0': 18, ':1': 17}),
-    WaveformDef('full-wav', {':0': 19, ':1': 18}),
-    WaveformDef('neg-full-wav', {':0': 20, ':1': 19}),
-    WaveformDef('half-wav', {':0': 21, ':1': 20}),
-    WaveformDef('neg-half-wav', {':0': 22, ':1': 21}),
-    WaveformDef('lorentz', {':0': 23, ':1': 22}),
-    WaveformDef('multitone', {':0': 24, ':1': 23}),
-    WaveformDef('rand', {':0': 25, ':1': 24}),
-    WaveformDef('ecg', {':0': 26, ':1': 25}),
-    WaveformDef('trap', {':0': 27, ':1': 26}),
-    WaveformDef('sinc', {':0': 28, ':1': 27}),
-    WaveformDef('impulse', {':0': 29, ':1': 28}),
-    WaveformDef('gauss', {':0': 30, ':1': 29}),
-    WaveformDef('am', {':0': 31, ':1': 30}),
-    WaveformDef('fm', {':0': 32, ':1': 31}),
-    WaveformDef('chirp', {':0': 33, ':1': 32}),
-]
+_WAVEFORMS = {
+    'sin': {':': 0},
+    'square': {':': 1},
+    'cmos': {':': 2, 'fy6900:': 4},
+    'adj-pulse': {':0': 3, 'fy6900:0': 5},
+    'dc': {':0': 4, ':1': 3, 'fy6900:0': 6, 'fy6900:1': 5},
+    'tri': {':0': 5, ':1': 4, 'fy6900:0': 7, 'fy6900:1': 6},
+    'ramp': {':0': 6, ':1': 5, 'fy6900:0': 8, 'fy6900:1': 7},
+    'neg-ramp': {':0': 7, ':1': 6, 'fy6900:0': 9, 'fy6900:1': 8},
+    'stair-tri': {':0': 8, ':1': 7, 'fy6900:0': 10, 'fy6900:1': 9},
+    'stair': {':0': 9, ':1': 8, 'fy6900:0': 11, 'fy6900:1': 10},
+    'neg-stair': {':0': 10, ':1': 9, 'fy6900:0': 12, 'fy6900:1': 11},
+    'exp': {':0': 11, ':1': 10, 'fy6900:0': 13, 'fy6900:1': 12},
+    'neg-exp': {':0': 12, ':1': 11, 'fy6900:0': 14, 'fy6900:1': 13},
+    'fall-exp': {':0': 13, ':1': 12, 'fy6900:0': 15, 'fy6900:1': 14},
+    'neg-fall-exp': {':0': 14, ':1': 13, 'fy6900:0': 16, 'fy6900:1': 15},
+    'log': {':0': 15, ':1': 14, 'fy6900:0': 17, 'fy6900:1': 16},
+    'neg-log': {':0': 16, ':1': 15, 'fy6900:0': 18, 'fy6900:1': 17},
+    'fall-log': {':0': 17, ':1': 16, 'fy6900:0': 19, 'fy6900:1': 18},
+    'neg-fall-log': {':0': 18, ':1': 17, 'fy6900:0': 20, 'fy6900:1': 19},
+    'full-wav': {':0': 19, ':1': 18, 'fy6900:0': 21, 'fy6900:1': 20},
+    'neg-full-wav': {':0': 20, ':1': 19, 'fy6900:0': 22, 'fy6900:1': 21},
+    'half-wav': {':0': 21, ':1': 20, 'fy6900:0': 23, 'fy6900:1': 22},
+    'neg-half-wav': {':0': 22, ':1': 21, 'fy6900:0': 24, 'fy6900:1': 23},
+    'lorentz': {':0': 23, ':1': 22, 'fy6900:0': 25, 'fy6900:1': 24},
+    'multitone': {':0': 24, ':1': 23, 'fy6900:0': 26, 'fy6900:1': 25},
+    'rand': {':0': 25, ':1': 24, 'fy6900:0': 27, 'fy6900:1': 26},
+    'ecg': {':0': 26, ':1': 25, 'fy6900:0': 28, 'fy6900:1': 27},
+    'trap': {':0': 27, ':1': 26, 'fy6900:0': 29, 'fy6900:1': 28},
+    'sinc': {':0': 28, ':1': 27, 'fy6900:0': 30, 'fy6900:1': 29},
+    'impulse': {':0': 29, ':1': 28, 'fy6900:0': 31, 'fy6900:1': 30},
+    'gauss': {':0': 30, ':1': 29, 'fy6900:0': 32, 'fy6900:1': 31},
+    'am': {':0': 31, ':1': 30, 'fy6900:0': 33, 'fy6900:1': 32},
+    'fm': {':0': 32, ':1': 31, 'fy6900:0': 34, 'fy6900:1': 33},
+    'chirp': {':0': 33, ':1': 32, 'fy6900:0': 35, 'fy6900:1': 34},
+    'rectangle': {'fy6900:': 2},
+    'tra': {'fy6900:': 3},
+}
 
 def _make_arb(count, start_dict):
   for arb_index in range(1, count + 1):
-    _WAVEFORM_DEFS.append(WaveformDef('arb%u' % arb_index, start_dict))
+    _WAVEFORMS['arb%u' % arb_index] = start_dict
     # create a new dictionary will all indexes incremented by one
     start_dict = dict((k, v+1) for k, v in six.iteritems(start_dict))
 
 # Add arb1, arb2 ... arb64
-_make_arb(64, {':0': 34, ':1': 33})
+_make_arb(64, {':0': 34, ':1': 33, 'fy6900:0': 36, 'fy6900:1': 35})
+
+def _make_waveform_defs():
+  return [
+      WaveformDef(name, mapping)
+      for name, mapping in _WAVEFORMS.items()
+  ]
+
+_WAVEFORM_DEFS = _make_waveform_defs()
+
 
 def _generate_waveform_id_dict():
   """Maps _WAVEFORM_DEFS -> _WAVEFORM_IDS.
@@ -247,7 +263,7 @@ def get_id(device_name, name, channel):
     if lookup in _WAVEFORM_IDS:
       return _WAVEFORM_IDS[lookup]
 
-  _check_is_supported(device_name)
+  check_is_supported(device_name)
 
   if channel not in (0, 1):
     raise InvalidChannelError(
@@ -280,7 +296,7 @@ def get_name(device_name, wave_id, channel):
     if lookup in _WAVEFORM_NAMES:
       return _WAVEFORM_NAMES[lookup]
 
-  _check_is_supported(device_name)
+  check_is_supported(device_name)
 
   if channel not in (0, 1):
     raise InvalidChannelError(
@@ -290,7 +306,7 @@ def get_name(device_name, wave_id, channel):
       'Invalid waveform id %d for device %s, channel %d.' %
       (wave_id, device_name, channel))
 
-def _check_is_supported(device_name):
+def check_is_supported(device_name):
   if device_name not in SUPPORTED_DEVICES:
     raise UnsupportedDeviceError(
         'Device %s is not supported.  Supported devices include %s' %
@@ -305,7 +321,7 @@ def get_valid_list(device_name=None, channel=None):
   if device_name is None and channel is None:
     return sorted(_WAVEFORMS_BY_NAME)
 
-  _check_is_supported(device_name)
+  check_is_supported(device_name)
 
   def is_valid(waveform):
     """Returns true if a waveform is valid."""
@@ -331,47 +347,77 @@ def get_description(waveform_name):
   return _WAVEFORMS_BY_NAME[waveform_name].description
 
 # pylint: disable=redefined-builtin
-def help(device_name='', fout=sys.stdout, use_markdown=False):
+def help(device_name=None, fout=sys.stdout, use_markdown=False):
   """Dumps a table of waveform names, along with supported devices and channels.
 
   Example output:
 
-  Name       Description       Channels
+  Name       Description       Channels   Devices
   ----------------------------------------------------
-  sin        Sin               all
-  adj-pulse  Adjustable Pulse  0
+  sin        Sin               all        all
+  adj-pulse  Adjustable Pulse  0          fy2300, fy6800
   ...
   """
-  _check_is_supported(device_name)
+  if device_name is not None:
+    check_is_supported(device_name)
 
-  def dump_row(name, description, channel):
-    fout.write('|%-15s|%-40s|%8s|\n' % (name, description, channel))
+  def dump_row(name, description, channel, device):
+    fout.write('|%-15s|%-30s|%8s|%8s|\n' % (name, description, channel, device))
 
-  def get_channels(waveform):
-    """Returns channels for a given waveform."""
+  def get_compatible(waveform):
+    """
+    Returns compatible devices and channels for a given waveform.
+    At the moment the output would be a bit confusing if two devices
+    support the same waveform but only on different channels.
+    Luckily there aren't any waveforms like that yet
+    """
     channel_set = set()
+    device_set = set()
     for mapping in waveform.mappings:
-      if mapping.startswith(':') or mapping.startswith('%s:' % device_name):
-        channel = mapping.split(':')[1]
+      is_included = (
+          mapping.startswith(':') or
+          mapping.startswith('%s:' % device_name) or
+          device_name is None
+      )
+      if is_included:
+        device, channel = mapping.split(':')
+        if not device:
+          device_set = SUPPORTED_DEVICES
+        else:
+          device_set.add(device)
+
         if not channel:
-          return '0, 1'
-        channel_set.add(channel)
+          channel_set.add('0')
+          channel_set.add('1')
+        else:
+          channel_set.add(channel)
 
     if not channel_set:
-      return None
+      return None, None
 
-    return ', '.join(sorted(channel_set))
+    if device_set == SUPPORTED_DEVICES:
+      device_text = 'all'
+    else:
+      device_text = ','.join(sorted(device_set))
+
+    channel_text = ', '.join(sorted(channel_set))
+    return (device_text, channel_text)
 
   def describe_waveform(waveform):
     """Dumps a waveform description line."""
-    channels = get_channels(waveform)
+    devices, channels = get_compatible(waveform)
     name = '`%s`' % waveform.name if use_markdown else waveform.name
     if channels:
-      dump_row(name, waveform.description, channels)
+      dump_row(name, waveform.description, channels, devices)
 
-  dump_row('Name', 'Description', 'Channels')
+  dump_row('Name', 'Description', 'Channels', 'Devices')
   fout.write(
-      '|---------------|----------------------------------------|--------|\n')
-  for waveform in _WAVEFORM_DEFS:
+      '|---------------|------------------------------|--------|--------|\n')
+
+  waveforms_arbs_last = sorted(
+      _WAVEFORM_DEFS,
+      key=lambda x: x.name.startswith('arb'),
+  )
+  for waveform in waveforms_arbs_last:
     describe_waveform(waveform)
 # pylint: enable=redefined-builtin


### PR DESCRIPTION
Hi!

I added support for FY6900 but along the way I made some other changes as well that affects current functionality, the main reason for this is that the waveform mapping for FY6900 is quite different from the other models.

### wavedef._WAVEFORM_DEFS

This has the same structure as before, but now all entries have the device prefix.
I don't think this is strictly needed, I can change it back to how it was before with device prefixes only for FY6900


### Model detection

If FYGen is not passed a device_name it now tries to use `get_model` to determine which model it is.
I have only tested this on FY6900 but it looks like it would work the same for the other models.

Since the autodetection happens at initialization time the test didn't have time to set `fy.is_serial = True` so I added an argument to the init method to be able to set this right away.

### xy_gcode_plot.py

I wasn't able to test this, my computer ran out of RAM, but I did some changes for python3 in there.


---

I haven't done any testing with python2, I know I put some python3-only things in there.
If you're interested in this PR and python2 I can make some changes for that as well
