### PR TITLE
Add baudrate parameter to FYGen constructor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ value.
     import fygen
     fy = fygen.FYGen('/dev/ttyUSB0', debug_level=1)
     fy = fygen.FYGen(debug_level=1)  # Same thing
+
+    # Some devices (e.g. FY2320) need the baudrate set to 9600.  See the
+    # troubleshooting section for more details.
+    fy = fygen.FYGen(baudrate=9600)
     
     # In case you get UnsupportedDeviceError, you can manually specify
     # one of the supported devices that may be compatible.
@@ -655,7 +659,11 @@ Start with the basics
     fy.send('WMW01')
 
 See if the UI on the generator responds.  If so, you have basic operations
-working.
+working.  If these basic commands do not respond, try initializing with a
+different baud rate (At least some and possibly all FY2320s need this change):
+
+    fy = fygen.FYGen(baudrate=9600)
+    fy.send('WMW01')
 
 The next thing to try is to turn on debug mode.
 

--- a/fygen.py
+++ b/fygen.py
@@ -211,6 +211,7 @@ class FYGen(object):
   def __init__(
       self,
       serial_path='/dev/ttyUSB0',
+      baudrate=115200,
       port=None,
       device_name=None,
       default_channel=0,
@@ -227,6 +228,8 @@ class FYGen(object):
     Args:
       serial_path: Path to usb serial device.  The format of this will vary by
         OS and will vary if you have multiple USB serial devices connected.
+      baudrate: Serial baud rate to use within the generator.  Users with
+        a FY2320 have reported needing to set this to 9600.
       port: If not None, specifies an output port.  In this case, path is
         ignored.  One usecase is to set port=sys.stdout to see the commands
         that will be sent.
@@ -259,7 +262,7 @@ class FYGen(object):
     else:
       self.port = serial.Serial(
           port=serial_path,
-          baudrate=115200,
+          baudrate=baudrate,
           bytesize=serial.EIGHTBITS,
           parity=serial.PARITY_NONE,
           stopbits=serial.STOPBITS_ONE,

--- a/fygen_help.py
+++ b/fygen_help.py
@@ -98,6 +98,10 @@ value.
     import fygen
     fy = fygen.FYGen('/dev/ttyUSB0', debug_level=1)
     fy = fygen.FYGen(debug_level=1)  # Same thing
+
+    # Some devices (e.g. FY2320) need the baudrate set to 9600.  See the
+    # troubleshooting section for more details.
+    fy = fygen.FYGen(baudrate=9600)
     
     # In case you get UnsupportedDeviceError, you can manually specify
     # one of the supported devices that may be compatible.
@@ -559,7 +563,11 @@ Start with the basics
     fy.send('WMW01')
 
 See if the UI on the generator responds.  If so, you have basic operations
-working.
+working.  If these basic commands do not respond, try initializing with a
+different baud rate (At least some and possibly all FY2320s need this change):
+
+    fy = fygen.FYGen(baudrate=9600)
+    fy.send('WMW01')
 
 The next thing to try is to turn on debug mode.
 


### PR DESCRIPTION
It has been discovered that some signal generators (FY2320) or some
potentially some firmware revisions are not initializing internal
UART communications at 115200 baud but 9600 baud instead.

Also added some information in the documentation introduction and
troubleshooting sections.