### PR TITLE
Add support for FY6300.

### DIFF
--- a/fygen_test.py
+++ b/fygen_test.py
@@ -1090,5 +1090,38 @@ class TestFYGen(unittest.TestCase):
     for device in SUPPORTED_DEVICES:
       self.assertEqual(fygen.detect_device(device), device)
 
+class TestFYGenFY6300(TestFYGen):
+  """Test harness for FY6300, which represents frequency differently in WMF/WFF command."""
+  def setUp(self):
+    self.output = six.StringIO()
+    self.fy = fygen.FYGen(
+      port=self.output,
+      init_state=False,
+      device_name='fy6300',
+    )
+
+  def tearDown(self):
+    self.fy.close()
+
+  def test_set_freq1(self):
+    """Sets a frequency using freq_hz."""
+    self.fy.set(freq_hz=5000)
+    self.fy.set(channel=1, freq_hz=1e6)
+    self.assertEqual(
+      'WMF00005000.000000\n'
+      'WFF01000000.000000\n',
+      self.output.getvalue())
+
+  def test_set_freq2(self):
+    """Sets a frequency using freq_uhz."""
+    self.fy.set(freq_uhz=5000)
+    self.fy.set(channel=1, freq_uhz=1e6)
+    self.assertEqual(
+      'WMF00000000.005000\n'
+      'WFF00000001.000000\n',
+      self.output.getvalue())
+
+
 if __name__ == '__main__':
   unittest.main()
+

--- a/wavedef.py
+++ b/wavedef.py
@@ -28,6 +28,7 @@ class UnsupportedDeviceError(Error):
 # mostly work anyway.
 SUPPORTED_DEVICES = set((
     'fy2300',
+    'fy6300',
     'fy6600',
     'fy6800',
     'fy6900',


### PR DESCRIPTION
Fairly straightforward, except that unlike other models supported so far, this one seems to require that the main frequency sent over the wire includes a decimal point.  A summary of my troubleshooting follows.

## Main wave Frequency must be represented in decimal Hz, not uHz as in previous models.
### Summary of the Issue
Put another way, the resolution of the main wave frequency is still 1 uHz as in other FeelTech generators, but when sending the frequency over the wire, you must include a decimal point (making the resulting string appear to be represented in decimal Hz).

For instance, to set the frequency to 123.4 kHz, `FYGen` would typically send: `WMF00001234000000`

1234000000 uHz = 1234 Hz = 1.234 kHz

...but to the FY6300, this appears to be asking for:

1234000000 Hz = 1.234 GHz

... which is of course too large and the FY6300 just sets its frequency to the maximum (50MHz in this case).

Sending the frequency with a decimal (e.g. `WMF01234.000000`) makes the FY6300 correctly interpret it as:

1234 Hz = 1.234 kHz

### Troubleshooting Setup
* FeelTech Model FY6300-50M, Firmware V2.3.2
* FeelTech CH1 output cabled into oscilloscope (Rigol ds1054z)

### Troubleshooting Examples:
```python
fy.send("WMF1000")
```
* Causes 00'001.000'000'000KHz to be displayed on the screen.
* Verified that the frequency is 1 kHz with oscope measurement.

```python
fy.send("WMF1")
```
* Causes 00'000.001'000'000KHz to be displayed on the screen.
* Verified that the frequency is 1Hz with oscope measurement.

```python
fy.send("WMF1000000")
```
* Causes 01'000.000'000'000KHz to be displayed on the screen.
* Verified that the frequency is 1MHz with oscope measurement.

#### Can go lower than 1Hz by including the decimal point:

```python
fy.send("WMF0.1")
```
* Causes 00'000.000'100'000KHz to be displayed on the screen.
* Verified the frequency 100mHz with oscope measurement.

##### Minimum Possible:
```python
fy.send("WMF0.000001")
```
* Causes 00'000.000'000'001KHz to be displayed on the screen.

### Modulation

Modulation frequency parameters like `hop_freq_hz` (command `WFK`) and `fm_bias_freq_hz` (command `WFM`) do not seem to require special treatment for the fy6300.
