### PR TITLE
Fix imports for external script to load this library as a package

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,2 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.realpath(__file__)))


### PR DESCRIPTION
Say you have an external script [similar to this one](https://github.com/michau-krakow/FY6900_setup/blob/main/setup_fy.py) and you want to use fygen from withing.
Actually `import fygen` fails because the import statements assume the script is being run from the same directory, which does not have to be true.
This commit is fixing imports for such scenario.